### PR TITLE
Update Chassis Elasticsearch module reference

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -8,4 +8,4 @@ version: 2
 
 dependencies:
   - chassis/nodejs
-  - chassis/chassis-elasticsearch
+  - chassis/chassis_elasticsearch


### PR DESCRIPTION
The Elasticsearch extension has been renamed as part of work to support the newer Ubuntu LTS release. We need to update the name we use to clone the project, or provisioning fails.